### PR TITLE
fix: umd error

### DIFF
--- a/components/GlobalModal.tsx
+++ b/components/GlobalModal.tsx
@@ -1,6 +1,6 @@
 import { useModalStore } from "@/stores/modalStore";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Animated, Modal, Pressable, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 export function GlobalModals() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "strict": true,
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
- React import 없이 JSX 사용 가능하게 설정
```
{
  "extends": "expo/tsconfig.base",
  "compilerOptions": {
    "jsx": "react-jsx", // 해당 라인
    "strict": true,
    "paths": {
      "@/*": ["./*"]
    }
  },
  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "nativewind-env.d.ts"]
}

```
- 이 line 이 없다면 Fragment 를 <> </> 이렇게 사용하면 , 'React' refers to a UMD global, but the - current file is a module. Consider adding an import instead.  해당 오류가 발생